### PR TITLE
Update for limpyd2 (redis-server>=3, redis-py>=3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,11 @@ python:
   - "3.6"
   - "3.7"
   - "3.8-dev"
-  - "pypy"
-  - "pypy3"
-
-env:
-  matrix:
-   - REDIS="redis==2.9.1"
-   - REDIS="redis==2.10.6"
+  - "pypy"  # 2.7
+  - "pypy3"  # 3.6
 
 install:
-- "pip install $REDIS"
-- "pip install ."
+- pip install .
 
 script: "python run_tests.py"
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Release *v2.0.dev0* - ``2019-10-08``
+------------------------------------
+* Support for limpyd >= 2 only (redis-py >= 3, redis-server >= 3)
+* Breaking change: `zadd` value/scores cannot be passed as positional arguments anymore
+
 Release *v1.1.1* - ``2019-10-11``
 ---------------------------------
 * Specify that limpyd 2 is not compatible with version 1.x
@@ -13,4 +18,4 @@ Release *v1.1* - ``2019-09-22``
 
 Release *v1.0* - ``2018-01-31``
 -------------------------------
-* Frist stable version
+* First stable version

--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ Install:
 
 Python versions 2.7, and 3.5 to 3.8 are supported (CPython and PyPy).
 
-Redis-py versions &gt;= 2.9.1, &lt; 2.11 are supported.
+Redis-server versions &gt;= 3 are supported.
 
-Redis-limpyd versions &gt;= 1.3, &lt; 2 are supported.
+Redis-py versions &gt;= 3 are supported.
+
+Redis-limpyd versions &gt;= 2 are supported.
+
+You can still use limpyd-extensions versions &lt; 2 if you need something older than the above requirements.
 
 ```bash
 pip install redis-limpyd-extensions
@@ -230,14 +234,14 @@ membership
 The standard:
 
 ```python
-group_2.members.zadd(sometime, somebody)  # sometime, a float, can be a call to time.time()
-group_3.members.zadd(another_time, somebody)
+group_2.members.zadd({somebody: sometime})  # sometime, a float, can be a call to time.time()
+group_3.members.zadd({somebody: another_time})
 ```
 
 is the same as the new:
 
 ```python
-somebody.membership.zadd(sometime, group2, another_time, group3)
+somebody.membership.zadd({group2: sometime, group3: another_time})
 ```
 
 -   `zrem` works the same way as `zadd`, without the score, but for

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,13 @@ Install:
 
 Python versions 2.7, and 3.5 to 3.8 are supported (CPython and PyPy).
 
-Redis-py versions >= 2.9.1, < 2.11 are supported.
+Redis-server versions >= 3 are supported.
 
-Redis-limpyd versions >= 1.3, < 2 are supported.
+Redis-py versions >= 3 are supported.
+
+Redis-limpyd versions >= 2 are supported.
+
+You can still use limpyd-extensions versions < 2 if you need something older than the above requirements.
 
 .. code:: bash
 
@@ -87,8 +91,8 @@ To use this, simple import the related fields from
 
 .. code:: python
 
-    from limpyd_extensions.related import (FKStringField, FKHashableField, 
-                                           M2MSetField, M2MListField, 
+    from limpyd_extensions.related import (FKStringField, FKHashableField,
+                                           M2MSetField, M2MListField,
                                            M2MSortedSetField)
 
 And use them as usual. (Note that for convenience you can also import
@@ -231,14 +235,14 @@ The standard:
 
 .. code:: python
 
-        group_2.members.zadd(sometime, somebody)  # sometime, a float, can be a call to time.time()
-        group_3.members.zadd(another_time, somebody)
+        group_2.members.zadd({somebody: sometime})  # sometime, a float, can be a call to time.time()
+        group_3.members.zadd({somebody: another_time})
 
 is the same as the new:
 
 .. code:: python
 
-        somebody.membership.zadd(sometime, group2, another_time, group3)
+        somebody.membership.zadd({group2: sometime, group3: another_time})
 
 -  ``zrem`` works the same way as ``zadd``, without the score, but for
    removing relations:

--- a/limpyd_extensions/related.py
+++ b/limpyd_extensions/related.py
@@ -145,10 +145,11 @@ class RelatedCollectionForSortedSet(_RelatedCollectionWithMethods):
         """
         if 'values_callback' not in kwargs:
             kwargs['values_callback'] = self._to_fields
-        pieces = fields.SortedSetField.coerce_zadd_args(*args, **kwargs)
-        for (score, related_field) in zip(*[iter(pieces)] * 2):
+
+        args, kwargs = fields.SortedSetField.coerce_zadd_args(*args, **kwargs)
+        for related_field, score in kwargs['mapping'].items():
             related_method = getattr(related_field, 'zadd')
-            related_method(score, self.instance._pk, values_callback=None)
+            related_method(**dict(kwargs, values_callback=None, mapping={self.instance._pk: score}))
 
     def zrem(self, *values):
         """

--- a/run_tests.py
+++ b/run_tests.py
@@ -43,4 +43,6 @@ if __name__ == "__main__":
             suite = unittest.TestLoader().loadTestsFromModule(mod)
             suites.append(suite)
         suite = unittest.TestSuite(suites)
-    unittest.TextTestRunner(verbosity=args.verbosity).run(suite)
+    result = unittest.TextTestRunner(verbosity=args.verbosity).run(suite)
+
+    sys.exit(not result.wasSuccessful())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = redis-limpyd-extensions
-version = 1.1.1
+version = 2.0.dev0
 author = Stephane "Twidi" Angel
 author_email = s.angel@twidi.com
 url = https://github.com/limpyd/redis-limpyd-extensions
@@ -31,8 +31,8 @@ classifiers =
 zip_safe = True
 packages = find:
 install_requires =
-    redis>=2.9.1,<2.11
-    redis-limpyd>=1.3,<2
+    redis>=3
+    redis-limpyd>=2
     future
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 

--- a/tests/dynamic/fields.py
+++ b/tests/dynamic/fields.py
@@ -163,7 +163,7 @@ class DynamicFieldsTest(LimpydBaseTest):
 
         # using real named argument (but not usable if complex one, it's ok here)
         somebody_cool_movies = Movie.collection(personal_tags_Somebody='cool')
-        self.assertEqual(set(somebody_cool_movies), attended)
+        self.assertSetEqual(set(somebody_cool_movies), attended)
 
         # using dict as collection arguments
         somebody_personal_tags = Movie.personal_tags.get_name_for(somebody_pk)
@@ -171,17 +171,17 @@ class DynamicFieldsTest(LimpydBaseTest):
             somebody_personal_tags: 'cool',
         }
         somebody_cool_movies = Movie.collection(**arg_dict)
-        self.assertEqual(set(somebody_cool_movies), attended)
+        self.assertSetEqual(set(somebody_cool_movies), attended)
 
         # using new dynamic_filter method
         somebody_cool_movies = Movie.collection().dynamic_filter('personal_tags', somebody_pk, 'cool')
-        self.assertEqual(set(somebody_cool_movies), attended)
+        self.assertSetEqual(set(somebody_cool_movies), attended)
 
         # and with the 4th parameter, the index suffix
         somebody_cool_movies = Movie.collection().dynamic_filter('personal_tags', somebody_pk, 'cool', 'eq')
-        self.assertEqual(set(somebody_cool_movies), attended)
+        self.assertSetEqual(set(somebody_cool_movies), attended)
         somebody_cool_movies = Movie.collection().dynamic_filter('personal_tags', somebody_pk, 'cool', '__eq')
-        self.assertEqual(set(somebody_cool_movies), attended)
+        self.assertSetEqual(set(somebody_cool_movies), attended)
 
     def test_dynamic_fields_should_work_with_advanced_index(self):
         class TestModel(TestRedisModelWithDynamicField):
@@ -236,7 +236,7 @@ class DynamicFieldsTest(LimpydBaseTest):
         personal_cool_drama = Movie.collection(tags='drama') \
                                    .dynamic_filter('personal_tags', somebody_pk, 'cool')
         attended = {'Fight club'}
-        self.assertEqual(set(personal_cool_drama), attended)
+        self.assertSetEqual(set(personal_cool_drama), attended)
 
     def test_dynamic_fields_should_work_for_strings(self):
         class TestModel(TestRedisModelWithDynamicField):
@@ -244,7 +244,7 @@ class DynamicFieldsTest(LimpydBaseTest):
             test_field = fields.DynamicStringField(indexable=True)
 
         instance = TestModel(test_field_1='foo')
-        self.assertEqual(set(TestModel.collection(test_field_1='foo')), {instance.pk.get()})
+        self.assertSetEqual(set(TestModel.collection(test_field_1='foo')), {instance.pk.get()})
 
     def test_dynamic_fields_should_work_for_instancehashes(self):
         class TestModel(TestRedisModelWithDynamicField):
@@ -252,7 +252,7 @@ class DynamicFieldsTest(LimpydBaseTest):
             test_field = fields.DynamicInstanceHashField(indexable=True)
 
         instance = TestModel(test_field_1='foo')
-        self.assertEqual(set(TestModel.collection(test_field_1='foo')), {instance.pk.get()})
+        self.assertSetEqual(set(TestModel.collection(test_field_1='foo')), {instance.pk.get()})
 
         # calling hmget with the defined dynamic field
         self.assertEqual(instance.hmget('test_field_1'), ['foo'])
@@ -276,7 +276,7 @@ class DynamicFieldsTest(LimpydBaseTest):
         instance = TestModel()
         field = instance.get_field('test_field_1')
         field.sadd('foo', 'bar')
-        self.assertEqual(set(TestModel.collection(test_field_1='foo')), {instance.pk.get()})
+        self.assertSetEqual(set(TestModel.collection(test_field_1='foo')), {instance.pk.get()})
 
     def test_dynamic_fields_should_work_for_lists(self):
         class TestModel(TestRedisModelWithDynamicField):
@@ -286,7 +286,7 @@ class DynamicFieldsTest(LimpydBaseTest):
         instance = TestModel()
         field = instance.get_field('test_field_1')
         field.lpush('foo', 'bar')
-        self.assertEqual(set(TestModel.collection(test_field_1='foo')), {instance.pk.get()})
+        self.assertSetEqual(set(TestModel.collection(test_field_1='foo')), {instance.pk.get()})
 
     def test_dynamic_fields_should_work_for_sortedsets(self):
         class TestModel(TestRedisModelWithDynamicField):
@@ -296,7 +296,7 @@ class DynamicFieldsTest(LimpydBaseTest):
         instance = TestModel()
         field = instance.get_field('test_field_1')
         field.zadd(foo=1, bar=2)
-        self.assertEqual(set(TestModel.collection(test_field_1='foo')), {instance.pk.get()})
+        self.assertSetEqual(set(TestModel.collection(test_field_1='foo')), {instance.pk.get()})
 
     def test_dynamic_fields_should_work_for_hashfields(self):
         class TestModel(TestRedisModelWithDynamicField):
@@ -307,8 +307,8 @@ class DynamicFieldsTest(LimpydBaseTest):
         field = instance.get_field('test_field_1')
         field.hmset(**{'foo': 'FOO', 'bar': 'BAR'})
         self.assertEqual(instance.test_field('1').hget('foo'), 'FOO')
-        self.assertEqual(set(TestModel.collection(test_field_1__foo='FOO')), {instance.pk.get()})
-        self.assertEqual(set(TestModel.collection().dynamic_filter('test_field__foo', '1', 'FOO')), {instance.pk.get()})
+        self.assertSetEqual(set(TestModel.collection(test_field_1__foo='FOO')), {instance.pk.get()})
+        self.assertSetEqual(set(TestModel.collection().dynamic_filter('test_field__foo', '1', 'FOO')), {instance.pk.get()})
 
     def test_inventory_should_be_filled_and_cleaned(self):
         somebody_pk = self.somebody.pk.get()

--- a/tests/dynamic/related.py
+++ b/tests/dynamic/related.py
@@ -123,12 +123,12 @@ class TestDynamicRelatedFields(LimpydBaseTest):
         # filter only on the dynamic field
         collection = Movie.collection().dynamic_filter('personal_tags', self.somebody, self.tags['cool'])
         attended = {self.fight_club.pk.get(), self.matrix.pk.get()}
-        self.assertEqual(set(collection), attended)
+        self.assertSetEqual(set(collection), attended)
 
         # filter with normal field too
         collection = Movie.collection(tags=self.tags['drama']).dynamic_filter('personal_tags', self.somebody, self.tags['cool'])
         attended = {self.fight_club.pk.get()}
-        self.assertEqual(set(collection), attended)
+        self.assertSetEqual(set(collection), attended)
 
     def test_related_collection_should_work_for_each_dynamic_variation(self):
         self.fight_club.personal_tags(self.somebody).sadd(self.tags['fight'], self.tags['cool'])
@@ -137,12 +137,12 @@ class TestDynamicRelatedFields(LimpydBaseTest):
         # filter only the dynamic field
         collection = self.tags['cool'].movies_for_people(self.somebody)
         attended = {self.fight_club.pk.get(), self.matrix.pk.get()}
-        self.assertEqual(set(collection), attended)
+        self.assertSetEqual(set(collection), attended)
 
         # filter with normal field too
         collection = self.tags['cool'].movies_for_people(self.somebody, tags=self.tags['drama'])
         attended = {self.fight_club.pk.get()}
-        self.assertEqual(set(collection), attended)
+        self.assertSetEqual(set(collection), attended)
 
     def test_dynamic_related_field_should_work_with_fkstringfield(self):
         class Tag(TestRedisModel):
@@ -169,10 +169,10 @@ class TestDynamicRelatedFields(LimpydBaseTest):
         self.assertEqual(somebody_it_main_tag, horror.pk.get())
 
         somebody_horror_books = horror.books(self.somebody)
-        self.assertEqual(set(somebody_horror_books), {it.pk.get(), carry.pk.get()})
+        self.assertSetEqual(set(somebody_horror_books), {it.pk.get(), carry.pk.get()})
 
         somebody_fiction_books = fiction.books(self.somebody)
-        self.assertEqual(set(somebody_fiction_books), {contact.pk.get()})
+        self.assertSetEqual(set(somebody_fiction_books), {contact.pk.get()})
 
     def test_dynamic_related_field_should_work_with_fkinstancehashfield(self):
         class Tag(TestRedisModel):
@@ -199,10 +199,10 @@ class TestDynamicRelatedFields(LimpydBaseTest):
         self.assertEqual(somebody_it_main_tag, horror.pk.get())
 
         somebody_horror_books = horror.books(self.somebody)
-        self.assertEqual(set(somebody_horror_books), {it.pk.get(), carry.pk.get()})
+        self.assertSetEqual(set(somebody_horror_books), {it.pk.get(), carry.pk.get()})
 
         somebody_fiction_books = fiction.books(self.somebody)
-        self.assertEqual(set(somebody_fiction_books), {contact.pk.get()})
+        self.assertSetEqual(set(somebody_fiction_books), {contact.pk.get()})
 
     def test_dynamic_related_field_should_work_with_m2mlistfield(self):
         class Tag(TestRedisModel):
@@ -234,11 +234,11 @@ class TestDynamicRelatedFields(LimpydBaseTest):
 
         somebody_cool_movies = cool.movies_for_people(self.somebody)
         attended = {fight_club.pk.get(), matrix.pk.get()}
-        self.assertEqual(set(somebody_cool_movies), attended)
+        self.assertSetEqual(set(somebody_cool_movies), attended)
 
         somebody_fight_movies = sf.movies_for_people(self.somebody)
         attended = {matrix.pk.get()}
-        self.assertEqual(set(somebody_fight_movies), attended)
+        self.assertSetEqual(set(somebody_fight_movies), attended)
 
     def test_dynamic_related_field_should_work_with_m2msortedsetfield(self):
         class Tag(TestRedisModel):
@@ -257,8 +257,8 @@ class TestDynamicRelatedFields(LimpydBaseTest):
         cool = Tag(slug='cool')
         sf = Tag(slug='sf')
 
-        fight_club.personal_tags(self.somebody).zadd(1, fight, 2, cool)
-        matrix.personal_tags(self.somebody).zadd(3, sf, 1, cool)
+        fight_club.personal_tags(self.somebody).zadd({fight: 1, cool: 2})
+        matrix.personal_tags(self.somebody).zadd({sf: 3, cool: 1})
 
         somebody_fight_club_tags = fight_club.personal_tags(self.somebody).zrange(0, -1)
         attended = [fight.pk.get(), cool.pk.get()]
@@ -270,11 +270,11 @@ class TestDynamicRelatedFields(LimpydBaseTest):
 
         somebody_cool_movies = cool.movies_for_people(self.somebody)
         attended = {fight_club.pk.get(), matrix.pk.get()}
-        self.assertEqual(set(somebody_cool_movies), attended)
+        self.assertSetEqual(set(somebody_cool_movies), attended)
 
         somebody_fight_movies = sf.movies_for_people(self.somebody)
         attended = {matrix.pk.get()}
-        self.assertEqual(set(somebody_fight_movies), attended)
+        self.assertSetEqual(set(somebody_fight_movies), attended)
 
     def test_inventory_should_be_filled_and_cleaned(self):
         somebody_pk = self.somebody.pk.get()

--- a/tests/related.py
+++ b/tests/related.py
@@ -44,158 +44,158 @@ class ReverseMethodsTest(LimpydBaseTest):
         # set the legacy way
         self.twidi.prefered_group.set(self.core_devs)
         self.assertEqual(self.twidi.prefered_group.get(), self.core_devs._pk)
-        self.assertEqual(set(self.core_devs.prefered_for()), {self.twidi._pk})
+        self.assertSetEqual(set(self.core_devs.prefered_for()), {self.twidi._pk})
 
         # set with the new reversed way
         self.fan_boys.prefered_for.sadd(self.twidi)
         self.assertEqual(self.twidi.prefered_group.get(), self.fan_boys._pk)
-        self.assertEqual(set(self.core_devs.prefered_for()), set())
-        self.assertEqual(set(self.fan_boys.prefered_for()), {self.twidi._pk})
+        self.assertSetEqual(set(self.core_devs.prefered_for()), set())
+        self.assertSetEqual(set(self.fan_boys.prefered_for()), {self.twidi._pk})
 
         # remove with the new reversed way
         self.fan_boys.prefered_for.srem(self.twidi)
         self.assertEqual(self.twidi.prefered_group.get(), None)
-        self.assertEqual(set(self.fan_boys.prefered_for()), set())
+        self.assertSetEqual(set(self.fan_boys.prefered_for()), set())
 
         # set many
         self.core_devs.prefered_for.sadd(self.twidi, self.ybon)
         self.assertEqual(self.twidi.prefered_group.get(), self.core_devs._pk)
         self.assertEqual(self.ybon.prefered_group.get(), self.core_devs._pk)
-        self.assertEqual(set(self.core_devs.prefered_for()), {self.twidi._pk, self.ybon._pk})
+        self.assertSetEqual(set(self.core_devs.prefered_for()), {self.twidi._pk, self.ybon._pk})
 
         # remove many
         self.core_devs.prefered_for.srem(self.twidi, self.ybon)
         self.assertEqual(self.twidi.prefered_group.get(), None)
         self.assertEqual(self.ybon.prefered_group.get(), None)
-        self.assertEqual(set(self.core_devs.prefered_for()), set())
+        self.assertSetEqual(set(self.core_devs.prefered_for()), set())
 
     def test_fkinstancehashfield(self):
         # set the legacy way
         self.fan_boys.parent.hset(self.main_group)
         self.assertEqual(self.fan_boys.parent.hget(), self.main_group._pk)
-        self.assertEqual(set(self.main_group.children()), {self.fan_boys._pk})
+        self.assertSetEqual(set(self.main_group.children()), {self.fan_boys._pk})
 
         # set with the new reversed way
         self.core_devs.children.sadd(self.fan_boys)
         self.assertEqual(self.fan_boys.parent.hget(), self.core_devs._pk)
-        self.assertEqual(set(self.main_group.children()), set())
-        self.assertEqual(set(self.core_devs.children()), {self.fan_boys._pk})
+        self.assertSetEqual(set(self.main_group.children()), set())
+        self.assertSetEqual(set(self.core_devs.children()), {self.fan_boys._pk})
 
         # remove with the new reversed way
         self.core_devs.children.srem(self.fan_boys)
         self.assertEqual(self.fan_boys.parent.hget(), None)
-        self.assertEqual(set(self.core_devs.children()), set())
+        self.assertSetEqual(set(self.core_devs.children()), set())
 
         # set many
         self.main_group.children.sadd(self.core_devs, self.fan_boys)
         self.assertEqual(self.core_devs.parent.hget(), self.main_group._pk)
         self.assertEqual(self.fan_boys.parent.hget(), self.main_group._pk)
-        self.assertEqual(set(self.main_group.children()), {self.core_devs._pk, self.fan_boys._pk})
+        self.assertSetEqual(set(self.main_group.children()), {self.core_devs._pk, self.fan_boys._pk})
 
         # remove many
         self.main_group.children.srem(self.core_devs, self.fan_boys)
         self.assertEqual(self.core_devs.parent.hget(), None)
         self.assertEqual(self.fan_boys.parent.hget(), None)
-        self.assertEqual(set(self.main_group.children()), set())
+        self.assertSetEqual(set(self.main_group.children()), set())
 
     def test_m2msetfield(self):
         # add with the legacy way
         self.core_devs.members.sadd(self.ybon)
-        self.assertEqual(set(self.core_devs.members()), {self.ybon._pk})
-        self.assertEqual(set(self.ybon.membership()), {self.core_devs._pk})
+        self.assertSetEqual(set(self.core_devs.members()), {self.ybon._pk})
+        self.assertSetEqual(set(self.ybon.membership()), {self.core_devs._pk})
 
         # add with the new reversed way
         self.twidi.membership.sadd(self.core_devs)
-        self.assertEqual(set(self.core_devs.members()), {self.ybon._pk, self.twidi._pk})
-        self.assertEqual(set(self.twidi.membership()), {self.core_devs._pk})
+        self.assertSetEqual(set(self.core_devs.members()), {self.ybon._pk, self.twidi._pk})
+        self.assertSetEqual(set(self.twidi.membership()), {self.core_devs._pk})
 
         # remove the legacy way
         self.core_devs.members.srem(self.ybon)
-        self.assertEqual(set(self.core_devs.members()), {self.twidi._pk})
-        self.assertEqual(set(self.ybon.membership()), set())
+        self.assertSetEqual(set(self.core_devs.members()), {self.twidi._pk})
+        self.assertSetEqual(set(self.ybon.membership()), set())
 
         # remove with the new reversed way
         self.twidi.membership.srem(self.core_devs)
-        self.assertEqual(set(self.core_devs.members()), set())
-        self.assertEqual(set(self.twidi.membership()), set())
+        self.assertSetEqual(set(self.core_devs.members()), set())
+        self.assertSetEqual(set(self.twidi.membership()), set())
 
         # add many
         self.twidi.membership.sadd(self.core_devs, self.fan_boys)
-        self.assertEqual(set(self.core_devs.members()), {self.twidi._pk})
-        self.assertEqual(set(self.fan_boys.members()), {self.twidi._pk})
-        self.assertEqual(set(self.twidi.membership()), {self.core_devs._pk, self.fan_boys._pk})
+        self.assertSetEqual(set(self.core_devs.members()), {self.twidi._pk})
+        self.assertSetEqual(set(self.fan_boys.members()), {self.twidi._pk})
+        self.assertSetEqual(set(self.twidi.membership()), {self.core_devs._pk, self.fan_boys._pk})
 
         # remove many
         self.twidi.membership.srem(self.core_devs, self.fan_boys)
-        self.assertEqual(set(self.core_devs.members()), set())
-        self.assertEqual(set(self.fan_boys.members()), set())
-        self.assertEqual(set(self.twidi.membership()), set())
+        self.assertSetEqual(set(self.core_devs.members()), set())
+        self.assertSetEqual(set(self.fan_boys.members()), set())
+        self.assertSetEqual(set(self.twidi.membership()), set())
 
     def test_m2mlistfield(self):
         # add with the legacy way
         self.core_devs.lmembers.rpush(self.ybon)
         self.assertEqual(list(self.core_devs.lmembers()), [self.ybon._pk])
-        self.assertEqual(set(self.ybon.lmembership()), {self.core_devs._pk})
+        self.assertSetEqual(set(self.ybon.lmembership()), {self.core_devs._pk})
 
         # add with the new reversed way
         self.twidi.lmembership.rpush(self.core_devs)
-        self.assertEqual(set(self.core_devs.lmembers()), {self.ybon._pk, self.twidi._pk})
-        self.assertEqual(set(self.twidi.lmembership()), {self.core_devs._pk})
+        self.assertSetEqual(set(self.core_devs.lmembers()), {self.ybon._pk, self.twidi._pk})
+        self.assertSetEqual(set(self.twidi.lmembership()), {self.core_devs._pk})
 
         # remove the legacy way
         self.core_devs.lmembers.lrem(0, self.ybon)
-        self.assertEqual(set(self.core_devs.lmembers()), {self.twidi._pk})
-        self.assertEqual(set(self.ybon.lmembership()), set())
+        self.assertSetEqual(set(self.core_devs.lmembers()), {self.twidi._pk})
+        self.assertSetEqual(set(self.ybon.lmembership()), set())
 
         # remove with the new reversed way
         self.twidi.lmembership.lrem(self.core_devs)
-        self.assertEqual(set(self.core_devs.lmembers()), set())
-        self.assertEqual(set(self.twidi.lmembership()), set())
+        self.assertSetEqual(set(self.core_devs.lmembers()), set())
+        self.assertSetEqual(set(self.twidi.lmembership()), set())
 
         # add many
         self.twidi.lmembership.rpush(self.core_devs, self.fan_boys)
-        self.assertEqual(set(self.core_devs.lmembers()), {self.twidi._pk})
-        self.assertEqual(set(self.fan_boys.lmembers()), {self.twidi._pk})
-        self.assertEqual(set(self.twidi.lmembership()), {self.core_devs._pk, self.fan_boys._pk})
+        self.assertSetEqual(set(self.core_devs.lmembers()), {self.twidi._pk})
+        self.assertSetEqual(set(self.fan_boys.lmembers()), {self.twidi._pk})
+        self.assertSetEqual(set(self.twidi.lmembership()), {self.core_devs._pk, self.fan_boys._pk})
 
         # remove many
         self.twidi.lmembership.lrem(self.core_devs, self.fan_boys)
-        self.assertEqual(set(self.core_devs.lmembers()), set())
-        self.assertEqual(set(self.fan_boys.lmembers()), set())
-        self.assertEqual(set(self.twidi.lmembership()), set())
+        self.assertSetEqual(set(self.core_devs.lmembers()), set())
+        self.assertSetEqual(set(self.fan_boys.lmembers()), set())
+        self.assertSetEqual(set(self.twidi.lmembership()), set())
 
     def test_m2msortedsetfield(self):
         t2 = time.time()
         t1 = t2 - 100
 
         # add with the legacy way
-        self.core_devs.zmembers.zadd(t1, self.ybon)
-        self.assertEqual(set(self.core_devs.zmembers()), {self.ybon._pk})
-        self.assertEqual(set(self.ybon.zmembership()), {self.core_devs._pk})
+        self.core_devs.zmembers.zadd({self.ybon: t1})
+        self.assertSetEqual(set(self.core_devs.zmembers()), {self.ybon._pk})
+        self.assertSetEqual(set(self.ybon.zmembership()), {self.core_devs._pk})
 
         # add with the new reversed way
-        self.twidi.zmembership.zadd(t2, self.core_devs)
-        self.assertEqual(set(self.core_devs.zmembers()), {self.ybon._pk, self.twidi._pk})
-        self.assertEqual(set(self.twidi.zmembership()), {self.core_devs._pk})
+        self.twidi.zmembership.zadd({self.core_devs: t2})
+        self.assertSetEqual(set(self.core_devs.zmembers()), {self.ybon._pk, self.twidi._pk})
+        self.assertSetEqual(set(self.twidi.zmembership()), {self.core_devs._pk})
 
         # remove the legacy way
         self.core_devs.zmembers.zrem(self.ybon)
-        self.assertEqual(set(self.core_devs.zmembers()), {self.twidi._pk})
-        self.assertEqual(set(self.ybon.zmembership()), set())
+        self.assertSetEqual(set(self.core_devs.zmembers()), {self.twidi._pk})
+        self.assertSetEqual(set(self.ybon.zmembership()), set())
 
         # remove with the new reversed way
         self.twidi.zmembership.zrem(self.core_devs)
-        self.assertEqual(set(self.core_devs.zmembers()), set())
-        self.assertEqual(set(self.twidi.zmembership()), set())
+        self.assertSetEqual(set(self.core_devs.zmembers()), set())
+        self.assertSetEqual(set(self.twidi.zmembership()), set())
 
         # add many
-        self.twidi.zmembership.zadd(t1, self.core_devs, t2, self.fan_boys)
-        self.assertEqual(set(self.core_devs.zmembers()), {self.twidi._pk})
-        self.assertEqual(set(self.fan_boys.zmembers()), {self.twidi._pk})
-        self.assertEqual(set(self.twidi.zmembership()), {self.core_devs._pk, self.fan_boys._pk})
+        self.twidi.zmembership.zadd({self.core_devs: t1, self.fan_boys: t2})
+        self.assertSetEqual(set(self.core_devs.zmembers()), {self.twidi._pk})
+        self.assertSetEqual(set(self.fan_boys.zmembers()), {self.twidi._pk})
+        self.assertSetEqual(set(self.twidi.zmembership()), {self.core_devs._pk, self.fan_boys._pk})
 
         # remove many
         self.twidi.zmembership.zrem(self.core_devs, self.fan_boys)
-        self.assertEqual(set(self.core_devs.zmembers()), set())
-        self.assertEqual(set(self.fan_boys.zmembers()), set())
-        self.assertEqual(set(self.twidi.zmembership()), set())
+        self.assertSetEqual(set(self.core_devs.zmembers()), set())
+        self.assertSetEqual(set(self.fan_boys.zmembers()), set())
+        self.assertSetEqual(set(self.twidi.zmembership()), set())


### PR DESCRIPTION
Only one important change: arguments for zadd cannot be passed as positional
arguments anymore